### PR TITLE
Add ktrace, profcs & hwpmc to FreeBSD section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Use grsec
 FreeBSD-specific recommendations
 ================================
 
-Disable ptrace(2)
+Disable ptrace(2), procfs(5), ktrace(2), hwpmc(4) and other debugging primitives.
 -----------------
 
 ```bash


### PR DESCRIPTION
Notes from sys/kern/kern_prot.c:

```
/*
 * The 'unprivileged_proc_debug' flag may be used to disable a variety of
 * unprivileged inter-process debugging services, including some procfs
 * functionality, ptrace(), and ktrace().  In the past, inter-process
 * debugging has been involved in a variety of security problems, and sites
 * not requiring the service might choose to disable it when hardening
 * systems.
```

See Also:
- hwpmc(4)
- p_candebug(9)
